### PR TITLE
Add a `cronitor` console script

### DIFF
--- a/cronitor/monitor.py
+++ b/cronitor/monitor.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
 import json
 import os
+import sys
+import argparse
 
 import requests
 
@@ -12,31 +15,36 @@ class Monitor(object):
         self.auth_key = auth_key or os.getenv('CRONITOR_AUTH_KEY')
         self.timezone = time_zone
 
-    def create(self, name=None, note=None, notifications=None, rules=None, tags=None):
-        payload = self.__prepare_payload(tags, name, note, notifications, rules)
+    def create(self, name=None, note=None, notifications=None,
+               rules=None, tags=None):
+        payload = self.__prepare_payload(tags, name, note,
+                                         notifications, rules)
         return self.__create(payload=payload)
 
-    def update(self, name=None, code=None, note=None, notifications=None, rules=None, tags=None):
-        payload = self.__prepare_payload(tags, name, note, notifications, rules)
+    def update(self, name=None, code=None, note=None,
+               notifications=None, rules=None, tags=None):
+        payload = self.__prepare_payload(tags, name, note,
+                                         notifications, rules)
         return self.__update(payload=payload, code=code)
 
     def delete(self, code):
         return self.__delete(code)
 
     def get(self, code):
-        return self.__get('{}/{}'.format(self.api_endpoint, code))
+        return self.__get('{0}/{1}'.format(self.api_endpoint, code))
 
-    def run(self, code):
-        return self.__ping(code, 'run')
+    def run(self, code, msg=''):
+        return self.__ping(code, 'run', msg=msg)
 
-    def complete(self, code):
+    def complete(self, code, msg=''):
         return self.__ping(code, 'complete')
 
-    def failed(self, code):
-        return self.__ping(code, 'failed')
+    def failed(self, code, msg=''):
+        return self.__ping(code, 'failed', msg=msg)
 
     def pause(self, code, hours):
-        return self.__get('{}/{}/pause/{}'.format(self.api_endpoint, code, hours))
+        return self.__get('{0}/{1}/pause/{2}'.format(self.api_endpoint,
+                                                     code, hours))
 
     def clone(self, code, name=None):
         return requests.post(self.api_endpoint,
@@ -45,9 +53,11 @@ class Monitor(object):
                              data=json.dumps({"code": code, name: name}),
                              headers={'content-type': 'application/json'})
 
-    def __ping(self, code, method):
+    def __ping(self, code, method, msg=''):
+        params = dict(auth_key=self.auth_key, msg=msg)
         return requests.get(
-            '{}/{}/{}?auth_key={}'.format(self.ping_endpoint, code, method, self.auth_key),
+            '{0}/{1}/{2}'.format(self.ping_endpoint, code, method),
+            params=params,
             timeout=10
         )
 
@@ -67,7 +77,7 @@ class Monitor(object):
                              )
 
     def __update(self, payload=None, code=None):
-        return requests.put('{}/{}'.format(self.api_endpoint, code),
+        return requests.put('{0}/{1}'.format(self.api_endpoint, code),
                             auth=(self.api_key, ''),
                             data=json.dumps(payload),
                             headers={'content-type': 'application/json'},
@@ -75,7 +85,7 @@ class Monitor(object):
                             )
 
     def __delete(self, code):
-        return requests.delete('{}/{}'.format(self.api_endpoint, code),
+        return requests.delete('{0}/{1}'.format(self.api_endpoint, code),
                                auth=(self.api_key, ''),
                                headers={'content-type': 'application/json'},
                                timeout=10
@@ -107,3 +117,46 @@ class Monitor(object):
             "tags": tags or [],
             "note": note
         }
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="cronitor",
+                     description='Send status messages to Cronitor ping API.')  # noqa
+    parser.add_argument('--authkey', '-a', type=str,
+                        default=os.getenv('CRONITOR_AUTH_KEY'),
+                        help='Auth Key from Account page')
+    parser.add_argument('--code', '-c', type=str,
+                        default=os.getenv('CRONITOR_CODE'),
+                        help='Code for Monitor to take action upon')
+    parser.add_argument('--msg', '-m', type=str, default='',
+                        help='Optional message to send with ping/fail')
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--run', '-r', action='store_true',
+                       help='Call ping on given Code')
+    group.add_argument('--complete', '-C', action='store_true',
+                       help='Call complete on given Code')
+    group.add_argument('--fail', '-f', action='store_true',
+                       help='Call fail on given Code')
+    group.add_argument('--pause', '-P', type=str, default=24,
+                       help='Call pause on given Code')
+
+    args = parser.parse_args()
+
+    if args.code is None:
+        print('A code must be supplied or CRONITOR_CODE ENV var used')
+        parser.print_help()
+        sys.exit(1)
+
+    monitor = Monitor(auth_key=args.authkey)
+
+    if args.run:
+        ret = monitor.run(args.code, msg=args.msg)
+    elif args.fail:
+        ret = monitor.fail(args.code, msg=args.msg)
+    elif args.complete:
+        ret = monitor.complete(args.code)
+    elif args.pause:
+        ret = monitor.pause(args.code, args.pause)
+
+    return ret.raise_for_status()

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,5 @@ setup(
     install_requires=[
         'requests',
     ],
-    entry_points={'console_scripts': [
-                     'cronitor = cronitor.monitor:main'
-                  ]
-    },
+    entry_points=dict(console_scripts=['cronitor = cronitor.monitor:main'])
 )

--- a/setup.py
+++ b/setup.py
@@ -12,4 +12,8 @@ setup(
     install_requires=[
         'requests',
     ],
+    entry_points={'console_scripts': [
+                     'cronitor = cronitor.monitor:main'
+                  ]
+    },
 )


### PR DESCRIPTION
Now you can use this framework for simple run/fail/complete/pause operations. Also cleanup some pep8 issues.

A future version might include the ability to execute a command in between calls to run/(complete|fail).