### PR TITLE
changed 'method' argument in failed method

### DIFF
--- a/cronitor/monitor.py
+++ b/cronitor/monitor.py
@@ -39,7 +39,7 @@ class Monitor(object):
         return self.__ping(code, 'complete', msg=msg)
 
     def failed(self, code, msg=''):
-        return self.__ping(code, 'failed', msg=msg)
+        return self.__ping(code, 'fail', msg=msg)
 
     def pause(self, code, hours):
         return self.__get('{0}/{1}/pause/{2}'.format(self.api_endpoint,


### PR DESCRIPTION
changed 'method' argument in failed method (passed in call to self.__ping) from 'failed' to 'fail'

Per the ping api docs (https://cronitor.io/docs/ping-api), the endpoint for failure is 'fail', not 'failed'.

### from the documentation:
/fail | Report task has failed.


